### PR TITLE
Remove numpy dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
 	long_description_content_type='text/markdown',
     license="MIT",
     keywords="spine, Python, atlas, SpineAtlas",
-    install_requires=["attrs", "numpy", "Pillow"],
+    install_requires=["attrs", "Pillow"],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
### Summary
This PR replaces the `numpy` implementation of `ImgPremultiplied` with a pure `PIL` implementation.
Currently, `numpy` is widely considered a heavy dependency, and it is only used in this single function throughout the entire codebase (approx. 500 lines). By refactoring this function, we can drop the `numpy` dependency, which significantly reduces the installation size and simplifies the environment setup for users.

### Changes
- Rewrote `ImgPremultiplied` using PIL's internal `RGBa` (premultiplied) to `RGBA` (straight) conversion logic.
- Removed `from numpy import ...` statements.
- Removed `numpy` from requirements.

### Technical Details
The new implementation uses a Pillow trick to perform the "un-premultiply" operation (converting premultiplied alpha back to straight alpha):
```python
# Treat raw bytes as 'RGBa' (premultiplied) and convert to 'RGBA' (straight)
# PIL handles the division (RGB / Alpha) internally in C.
raw_data = image.tobytes()
premul_image = imgcr('RGBa', image.size)
premul_image.frombytes(raw_data)
tex = premul_image.convert('RGBA')
return tex
```

### Verification & Accuracy
I compared the output of the original `numpy` version and the new `PIL` version using the following method:
1.  Generated output images from both functions.
2.  Layered them in Paint.NET(an image editor), set their alpha to 255 and applied the "XOR" (Difference) blending mode.
3.  **Result**: The difference is practically non-existent. The image is almost entirely black, with only negligible deviations (mostly 0x01 in one of the color channels) in a few pixels due to floating-point rounding differences between Numpy and PIL's internal integer arithmetic.

### Impact
* Removes the need for `numpy`.